### PR TITLE
Improve openai stub validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ data you send will therefore be transmitted to a third-party service
 (OpenAI) for processing.
 
 For local tests the repository bundles an `openai_stub` module that mimics the
-API without making network calls. This stub is only meant for running the test
-suite. Replace it with the genuine `openai` package in production so the
-application can contact OpenAI's servers.
+API without making network calls.  The stub now performs basic validation and
+raises a custom `OpenAIError` when invalid input is provided so tests can cover
+error conditions.  Replace it with the genuine `openai` package in production so
+the application can contact OpenAI's servers.
 
 ## Cloth Segmentation Model
 

--- a/openai_stub/__init__.py
+++ b/openai_stub/__init__.py
@@ -1,13 +1,29 @@
 class ChatCompletion:
+    """Simplified stand-in for ``openai.ChatCompletion``.
+
+    The stub validates basic input and raises ``OpenAIError`` on invalid
+    arguments to better mimic the real client.
+    """
+
     @staticmethod
     def create(*, messages, model="gpt-3.5-turbo"):
-        content = messages[-1]["content"] if messages else ""
+        """Return a deterministic response based on the last user message."""
+
+        if not messages or "content" not in messages[-1] or not messages[-1]["content"]:
+            raise error.OpenAIError("Invalid messages")
+
+        content = messages[-1]["content"]
         suggestion = f"AI suggestion based on {content}"
         return {"choices": [{"message": {"content": suggestion}}]}
 
 class Image:
+    """Simplified stand-in for ``openai.Image`` that validates input."""
+
     @staticmethod
     def create(*, prompt, n=1, size="512x512"):
+        if not prompt:
+            raise error.OpenAIError("Prompt required")
+
         url = f"https://example.com/{prompt.replace(' ', '_')}.png"
         return {"data": [{"url": url}]}
 

--- a/tests/test_openai_stub.py
+++ b/tests/test_openai_stub.py
@@ -1,0 +1,19 @@
+import openai_stub
+
+
+def test_chatcompletion_invalid_messages():
+    try:
+        openai_stub.ChatCompletion.create(messages=[])
+    except openai_stub.error.OpenAIError:
+        pass
+    else:
+        raise AssertionError("OpenAIError not raised")
+
+
+def test_image_invalid_prompt():
+    try:
+        openai_stub.Image.create(prompt="")
+    except openai_stub.error.OpenAIError:
+        pass
+    else:
+        raise AssertionError("OpenAIError not raised")


### PR DESCRIPTION
## Summary
- validate inputs in openai_stub and raise OpenAIError on bad data
- document stub error handling in README
- test the new validation logic

## Testing
- `python -m pytest -q`