### PR TITLE
Improve ClothSegmenter fallback

### DIFF
--- a/clothseg.py
+++ b/clothseg.py
@@ -118,7 +118,15 @@ class ClothSegmenter:
         parts = ["upper_body", "lower_body", "full_body"]
 
         if self.model is None:  # pragma: no cover - dummy path
-            return {part: [] for part in parts}
+            width, height = self._get_image_size(image_path)
+            if width == 0 or height == 0:
+                return {part: [] for part in parts}
+            half = height // 2
+            return {
+                "upper_body": [[0, 0, width, half]],
+                "lower_body": [[0, half, width, height]],
+                "full_body": [[0, 0, width, height]],
+            }
 
         # Real inference path. This branch is not executed in tests as it
         # requires PyTorch and model weights.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -143,7 +143,13 @@ def test_parse_route(client):
     )
     assert response.status_code == 200
     payload = response.get_json()
-    assert 'parts' in payload
+    assert payload == {
+        'parts': {
+            'upper_body': [[0, 0, 1, 0]],
+            'lower_body': [[0, 0, 1, 1]],
+            'full_body': [[0, 0, 1, 1]],
+        }
+    }
 
 def test_parse_route_no_file(client):
     response = client.post(


### PR DESCRIPTION
## Summary
- generate basic bounding boxes when no segmentation model is loaded
- check these dummy boxes in the parse route test

## Testing
- `python -m pytest -q`