### PR TITLE
Add mimetype property to File stub

### DIFF
--- a/flask_stub/__init__.py
+++ b/flask_stub/__init__.py
@@ -1,3 +1,6 @@
+import mimetypes
+
+
 class Request:
     def __init__(self, form=None, files=None):
         self.form = form or {}
@@ -8,6 +11,7 @@ class File:
     def __init__(self, stream, filename):
         self.stream = stream
         self.filename = filename
+        self.mimetype = mimetypes.guess_type(filename)[0]
 
     def save(self, path):
         with open(path, 'wb') as f:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,7 @@ import types
 import contextlib
 import pytest
 from unittest.mock import patch
+from flask_stub import File
 
 from app import app
 import app as app_module
@@ -564,3 +565,10 @@ def test_real_parser_with_weights():
         result = seg.parse(img_path)
 
     assert all(result[p] for p in ('upper_body', 'lower_body', 'full_body'))
+
+
+def test_is_allowed_image_uses_mimetype():
+    """File with disallowed extension should pass if mimetype is allowed."""
+    f = File(io.BytesIO(PNG_BYTES), 'foo.bad')
+    f.mimetype = 'image/png'
+    assert app_module._is_allowed_image(f)


### PR DESCRIPTION
## Summary
- set `mimetype` on `flask_stub.File`
- test that `_is_allowed_image` accepts a disallowed extension when mimetype matches

## Testing
- `python -m pytest -q`