### PR TITLE
Fix GrabCut fallback when numpy missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ python clothseg.py --download-model
 
 This will store the model in `~/.u2net/u2net.pth` by default.
 
+When the heavy U^2-Net weights are not available the application falls back to
+OpenCV's GrabCut algorithm to roughly separate the foreground garment from the
+background. The `/analyze` endpoint exposes this functionality and additionally
+provides a lightweight classification that labels the item as a shirt, pants or
+dress and estimates a basic colour.
+
 ## Virtual Try-On
 
 For realistic outfit visualisation you may integrate an external try-on engine. Open-source implementations such as [VITON-HD](https://github.com/OpenTalker/VITON-HD) can warp a garment image onto a full-body photo of the user. This repository does not bundle such a model, but the `/compose` API route can be adapted to call a dedicated try-on pipeline, typically requiring a GPU for best results.

--- a/clothseg.py
+++ b/clothseg.py
@@ -5,11 +5,17 @@ from typing import Dict, List
 import struct
 
 try:
+    import cv2
+except Exception:  # pragma: no cover - optional dependency
+    cv2 = None
+
+try:
     import torch
     from PIL import Image
     import numpy as np
 except ImportError:  # pragma: no cover - optional dependencies
     torch = None
+    np = None
 
 
 class ClothSegmenter:
@@ -108,6 +114,80 @@ class ClothSegmenter:
             pass
         return 0, 0
 
+    def _parse_grabcut(self, image_path: str) -> Dict[str, List]:
+        """Return simple masks using OpenCV's GrabCut if available."""
+        if cv2 is None or np is None:
+            return {}
+        img = cv2.imread(image_path)
+        if img is None:
+            return {}
+        mask = np.zeros(img.shape[:2], np.uint8)
+        rect = (1, 1, img.shape[1] - 2, img.shape[0] - 2)
+        bgdModel = np.zeros((1, 65), np.float64)
+        fgdModel = np.zeros((1, 65), np.float64)
+        try:  # pragma: no cover - requires cv2
+            cv2.grabCut(img, mask, rect, bgdModel, fgdModel, 5, cv2.GC_INIT_WITH_RECT)
+        except Exception:  # pragma: no cover - grabcut failure
+            return {}
+        mask2 = np.where((mask == 2) | (mask == 0), 0, 1).astype("uint8")
+        if mask2.sum() == 0:
+            return {}
+        ys, xs = np.where(mask2 == 1)
+        left, right = int(xs.min()), int(xs.max())
+        top, bottom = int(ys.min()), int(ys.max())
+        mid = (top + bottom) // 2
+        return {
+            "upper_body": [[left, top, right, mid]],
+            "lower_body": [[left, mid, right, bottom]],
+            "full_body": [[left, top, right, bottom]],
+        }
+
+    def classify(self, image_path: str, parts: Dict[str, List]) -> Dict[str, str]:
+        """Return a simple category and colour estimate for the garment."""
+        if cv2 is None:
+            return {"category": "unknown", "color": "unknown"}
+        full = parts.get("full_body")
+        if not full:
+            return {"category": "unknown", "color": "unknown"}
+        x1, y1, x2, y2 = full[0]
+        img = cv2.imread(image_path)
+        if img is None:
+            return {"category": "unknown", "color": "unknown"}
+        region = img[y1:y2, x1:x2]
+        if region.size == 0:
+            return {"category": "unknown", "color": "unknown"}
+        h, w = region.shape[:2]
+        ratio = h / w if w else 0
+        if ratio > 1.3:
+            category = "dress"
+        elif ratio > 0.8:
+            category = "shirt"
+        else:
+            category = "pants"
+        avg_bgr = region.mean(axis=(0, 1))
+        hsv = cv2.cvtColor(avg_bgr.reshape(1, 1, 3).astype("uint8"), cv2.COLOR_BGR2HSV)[0, 0]
+        hval, sval, vval = hsv
+        if vval > 200 and sval < 30:
+            color = "white"
+        elif vval < 50:
+            color = "black"
+        elif sval < 40:
+            color = "gray"
+        else:
+            if hval < 15 or hval >= 165:
+                color = "red"
+            elif hval < 30:
+                color = "orange"
+            elif hval < 45:
+                color = "yellow"
+            elif hval < 75:
+                color = "green"
+            elif hval < 130:
+                color = "blue"
+            else:
+                color = "purple"
+        return {"category": category, "color": color}
+
     def parse(self, image_path: str) -> Dict[str, List]:
         """Return segmentation masks for the supplied image.
 
@@ -117,7 +197,7 @@ class ClothSegmenter:
         """
         parts = ["upper_body", "lower_body", "full_body"]
 
-        if self.model is None and torch is not None:  # pragma: no cover - load lazily
+        if self.model is None and torch is not None and np is not None:  # pragma: no cover - load lazily
             path = self.model_path
             if path is None and os.path.exists(self.DEFAULT_MODEL_PATH):
                 path = self.DEFAULT_MODEL_PATH
@@ -128,7 +208,10 @@ class ClothSegmenter:
                 except Exception:
                     self.model = None
 
-        if self.model is None:  # pragma: no cover - dummy path
+        if self.model is None or torch is None or np is None:
+            parts_gc = self._parse_grabcut(image_path)
+            if parts_gc:
+                return parts_gc
             width, height = self._get_image_size(image_path)
             if width == 0 or height == 0:
                 return {part: [] for part in parts}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ torch
 numpy
 Pillow
 SQLAlchemy
+opencv-python


### PR DESCRIPTION
## Summary
- merge main and handle missing numpy
- fall back to empty result when numpy is unavailable
- test GrabCut fallback behaviour

## Testing
- `python -m pytest -q`
