### PR TITLE
feat: Enhance outfit suggestion AI and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,15 @@ background. The `/analyze` endpoint exposes this functionality and additionally
 provides a lightweight classification that labels the item as a shirt, pants or
 dress and estimates a basic colour.
 
-## Virtual Try-On
+## Advanced Features
 
-For realistic outfit visualisation you may integrate an external try-on engine. Open-source implementations such as [VITON-HD](https://github.com/OpenTalker/VITON-HD) can warp a garment image onto a full-body photo of the user. This repository does not bundle such a model, but the `/compose` API route can be adapted to call a dedicated try-on pipeline, typically requiring a GPU for best results.
+### Virtual Try-On
 
-## Outfit Scoring with GPT-4
+The application currently uses general AI image generation (via OpenAI's DALL-E) for visual compositions in endpoints like `/compose`. This means it generates new images based on textual descriptions derived from uploaded items rather than performing a true virtual try-on.
+
+A true virtual try-on system would involve overlaying specific garment images onto a user's photo, preserving their pose and body shape while realistically draping the clothes. This is a complex R&D task requiring specialized machine learning models. For more details on how such a system could be conceptualized and integrated, please see the [Virtual Try-On Implementation Guide](./VIRTUAL_TRY_ON.md). The existing `/compose` endpoint is a starting point for such an integration.
+
+### Outfit Scoring with GPT-4
 
 The application uses OpenAI's chat completions API to generate outfit suggestions. By default it calls the `gpt-3.5-turbo` model, but you can switch to GPT-4 by setting the `model` parameter in `app.py` to `gpt-4`. GPT-4 can reason about style compatibility using textual metadata for each garment, serving as a lighter alternative to specialised transformer models.
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -1,0 +1,145 @@
+# Setup Guide: Enabling Full Application Functionality
+
+## Introduction
+
+This guide provides step-by-step instructions to set up and run this application with all its features enabled, including AI-powered functionalities and accurate cloth segmentation. Following these steps will ensure you are using the real libraries and not the placeholder stubs.
+
+## Prerequisites
+
+Before you begin, ensure you have the following:
+
+*   **Python 3.x installed:** You can download it from [python.org](https://www.python.org/downloads/).
+*   **Access to a terminal or command prompt:** This will be used for running commands.
+
+## Installation
+
+1.  **Clone the Repository (if you haven't already):**
+    If you're working with a fresh copy or setting this up in a new environment, you'd typically clone the repository. However, as you're likely already viewing this within the project, you can skip this step.
+    ```bash
+    # git clone <repository-url>
+    # cd <repository-name>
+    ```
+
+2.  **Set Up a Virtual Environment (Recommended):**
+    Using a virtual environment keeps your project dependencies isolated.
+    ```bash
+    python -m venv venv
+    ```
+    Activate it:
+    *   On Windows: `venv\Scripts\activate`
+    *   On macOS and Linux: `source venv/bin/activate`
+
+3.  **Install Python Dependencies:**
+    This project uses a `requirements.txt` file to manage its dependencies. Install them using pip:
+    ```bash
+    pip install -r requirements.txt
+    ```
+    **Important:** This command installs the *real* versions of libraries like Flask, OpenAI, SQLAlchemy, etc., which are necessary for full functionality.
+
+## Configuration
+
+To unlock the application's advanced features, you need to configure a few things:
+
+### 1. OpenAI API Key
+
+The application uses the OpenAI API for its AI-powered features.
+
+*   **Obtain an OpenAI API Key:**
+    1.  Go to [platform.openai.com/signup](https://platform.openai.com/signup) to create an account or log in.
+    2.  Navigate to the [API keys section](https://platform.openai.com/account/api-keys).
+    3.  Create a new secret key and copy it immediately. You won't be able to see it again.
+
+*   **Set the `OPENAI_API_KEY` Environment Variable:**
+    The application expects the API key to be available as an environment variable named `OPENAI_API_KEY`.
+    *   **macOS/Linux:**
+        ```bash
+        export OPENAI_API_KEY='your_api_key_here'
+        ```
+        To make this permanent, add the line to your shell's configuration file (e.g., `~/.bashrc`, `~/.zshrc`) and then source it (e.g., `source ~/.bashrc`).
+    *   **Windows (Command Prompt):**
+        ```bash
+        set OPENAI_API_KEY=your_api_key_here
+        ```
+    *   **Windows (PowerShell):**
+        ```bash
+        $env:OPENAI_API_KEY="your_api_key_here"
+        ```
+        For permanent storage on Windows, search for "environment variables" in the system settings.
+
+    **Crucial:** Without this key, AI features will not work, and you might encounter errors or see stubbed responses.
+
+### 2. Cloth Segmentation Model (U^2-Net)
+
+For accurate clothing segmentation in images, the application uses `clothseg.py`, which leverages the U^2-Net pre-trained model.
+
+*   **Download the Model:**
+    The `u2net.pth` model file (approximately 176MB) needs to be downloaded. You can do this by running the `clothseg.py` script with a special command:
+    ```bash
+    python clothseg.py --download-model
+    ```
+    This command will download the model to the default location: `~/.u2net/u2net.pth` (i.e., a `.u2net` directory in your user's home directory).
+
+*   **Automatic Usage:**
+    The `ClothSegmenter` class in `clothseg.py` is designed to automatically look for `u2net.pth` in the default path (`~/.u2net/u2net.pth`). If the model is found there, it will be loaded and used. You can also specify a custom path to the model if needed when instantiating `ClothSegmenter`.
+
+## Ensuring Real Libraries are Used (Crucial)
+
+As mentioned in the `README.md`, this repository includes stub modules (`flask_stub/`, `openai_stub/`, `sqlalchemy_stub/`, `werkzeug_stub/`) to allow basic exploration without installing all dependencies or setting up API keys. **For full functionality, these stubs MUST NOT be used.**
+
+To ensure the real libraries (installed via `pip install -r requirements.txt`) are used:
+
+*   **Option 1: Remove the Stub Directories (Recommended):**
+    This is the cleanest way to ensure the stubs don't interfere. Delete the following directories from your project's root:
+    *   `flask_stub/`
+    *   `openai_stub/`
+    *   `sqlalchemy_stub/`
+    *   `werkzeug_stub/`
+
+*   **Option 2: Run from an External Directory (If stubs must be kept):**
+    If you have a specific reason to keep the stub directories in your project, you must ensure that Python does not find them when looking for modules. The easiest way to do this is to run the application from a directory *outside* the project's root. Python's module search path (`PYTHONPATH`) typically includes the current working directory first. If you run `python app.py` from within the project root, it might pick up `openai_stub` instead of the real `openai` library.
+
+    **We strongly recommend removing the stub directories for any development or production setup to avoid confusion.**
+
+## Database Setup
+
+The application uses SQLAlchemy for database interactions.
+
+*   By default, it uses an in-memory SQLite database (`sqlite:///:memory:`). This is often sufficient for development and testing, as the database is created anew each time the application starts.
+*   You can specify a different database by setting the `DATABASE_URL` environment variable (e.g., `export DATABASE_URL='postgresql://user:password@host:port/dbname'`).
+
+For standard setup and testing the full features, the default in-memory database is fine.
+
+## Running the Application
+
+Once all dependencies are installed, configurations are set, and you've ensured stubs won't interfere:
+
+1.  **Ensure your virtual environment is active.**
+2.  **Set `FLASK_DEBUG=1` for development mode (provides helpful debugging information):**
+    ```bash
+    export FLASK_DEBUG=1 # macOS/Linux
+    # set FLASK_DEBUG=1   # Windows Command Prompt
+    # $env:FLASK_DEBUG="1" # Windows PowerShell
+    ```
+3.  **Run the application:**
+    ```bash
+    python app.py
+    ```
+4.  **Access the application:**
+    Open your web browser and go to `http://localhost:5000`.
+
+## Troubleshooting (Brief)
+
+*   **"OpenAI API key not set" / AI features not working:**
+    *   Double-check that you have correctly set the `OPENAI_API_KEY` environment variable.
+    *   Ensure the key itself is valid and has API access on the OpenAI platform.
+    *   Restart your terminal or command prompt session after setting the variable to ensure it's loaded.
+
+*   **"Cloth segmentation is coarse" / Background removal is poor:**
+    *   Ensure you have downloaded the `u2net.pth` model using `python clothseg.py --download-model`.
+    *   Verify the model is in the expected location (`~/.u2net/u2net.pth`) or that `clothseg.py` is correctly configured if using a custom path.
+
+*   **"Still seeing stub behavior" / Application seems limited:**
+    *   You are likely still using the stub modules. **Strongly ensure you have removed the `flask_stub/`, `openai_stub/`, `sqlalchemy_stub/`, and `werkzeug_stub/` directories.**
+    *   If you opted not to remove them, make sure you are running `python app.py` from a directory *outside* the project's root.
+
+By following this guide, you should have a fully functional instance of the application running.

--- a/VIRTUAL_TRY_ON.md
+++ b/VIRTUAL_TRY_ON.md
@@ -1,0 +1,71 @@
+# Virtual Try-On: Advanced Implementation Guide
+
+## Introduction
+
+Currently, the application features AI-driven image generation (e.g., in the `/upload` or `/compose` endpoints) that creates new images based on textual prompts derived from user inputs or selected clothing items. This is distinct from a **true virtual try-on** system.
+
+A true virtual try-on system aims to take an image of a specific person and overlay specific garment images onto them in a realistic manner, making it appear as if the person is actually wearing those clothes. This involves preserving the person's identity, pose, and body shape while accurately draping and rendering the selected garments.
+
+## Challenges
+
+Implementing a true virtual try-on system is a complex task with several challenges:
+*   **Specialized Models:** Requires sophisticated deep learning models specifically trained for human parsing, garment segmentation, and image synthesis.
+*   **Computational Resources:** Training and often even running these models can be computationally intensive, typically requiring GPUs.
+*   **Data Preprocessing:** Models have strict input requirements, often needing precise segmentation of the person and the garment, pose estimation, and alignment.
+*   **Realism and Accuracy:** Achieving a high degree of realism in terms of fit, drape, texture, and lighting is difficult.
+
+## Potential Models/Technologies
+
+Several approaches and models have been developed in this domain. Here are some starting points for research:
+
+*   **VITON-HD (High-Definition Virtual Try-On):** This is a well-known research model in the virtual try-on space, often cited for its quality. Implementations and papers can be found by searching for "VITON-HD."
+*   **Generative Adversarial Networks (GANs):** Many virtual try-on systems are based on GANs. These networks consist of a generator (creates the try-on image) and a discriminator (tries to distinguish real images from generated ones), which are trained together to produce realistic outputs.
+*   **Diffusion Models:** More recent advancements in image generation, diffusion models have shown remarkable capabilities and are increasingly being applied to tasks like virtual try-on. They work by gradually adding noise to an image and then learning to reverse the process.
+*   **Open-Source Projects:** Platforms like GitHub are valuable resources. Search for terms like:
+    *   "virtual try-on"
+    *   "fashion GAN"
+    *   "image-based try-on"
+    *   "cloth generation"
+    *   "garment transfer"
+
+## General Integration Steps
+
+Integrating a chosen virtual try-on model into this Flask application would generally involve the following steps:
+
+1.  **Model Selection:**
+    *   Thoroughly research available models based on performance, ease of use, licensing, and community support.
+    *   Consider factors like input requirements, output quality, and inference speed.
+
+2.  **Setup:**
+    *   Install the chosen model and its dependencies. This might involve setting up a specific Python environment (e.g., using Conda or venv).
+    *   Install necessary deep learning frameworks (e.g., TensorFlow, PyTorch).
+    *   If the model requires a GPU, ensure appropriate GPU drivers (e.g., CUDA for NVIDIA GPUs) are installed and configured.
+
+3.  **API/Wrapper Creation:**
+    *   The Flask application needs a way to communicate with the try-on model.
+    *   If the model is a Python script or library, you might wrap its core logic in a function that can be called from the Flask app.
+    *   If the model is set up as a separate service (e.g., a Docker container running an API), the Flask app would make HTTP requests to it.
+
+4.  **Image Preprocessing:**
+    *   This is a critical step. Virtual try-on models have very specific input requirements. You'll likely need to:
+        *   **Person Image Processing:**
+            *   Segment the person from the background.
+            *   Perform pose estimation to get keypoints (e.g., locations of shoulders, hips, elbows).
+            *   Generate a representation of the person's shape or body mask.
+        *   **Garment Image Processing:**
+            *   Segment the garment from its background.
+            *   Potentially create a mask for the garment.
+    *   Libraries like OpenCV, Pillow, and specialized tools provided by the model's authors (e.g., for human parsing or pose estimation like OpenPose) will be essential.
+
+5.  **Flask Endpoint Modification (e.g., `/compose`):**
+    *   The existing `/compose` endpoint in `app.py` is the most logical candidate for integrating true virtual try-on functionality.
+    *   It would need to be significantly modified:
+        *   **Input:** Accept the user's full-body image (person image) and one or more garment images.
+        *   **Preprocessing Call:** Call the image preprocessing functions/logic developed in step 4 for both the person and garment images.
+        *   **Model Invocation:** Send the preprocessed data (e.g., pose keypoints, person mask, garment mask) to the virtual try-on model via the API/wrapper created in step 3.
+        *   **Output Handling:** Receive the resulting try-on image from the model.
+        *   **Response:** Return the generated try-on image to the frontend.
+
+## Disclaimer
+
+Implementing a robust and high-quality virtual try-on system is a significant research and development effort. It goes beyond simple API calls to services like OpenAI's DALL-E (which is prompt-based) and involves a deeper dive into specialized machine learning models, image processing techniques, and potentially MLOps for deployment and management. The steps outlined above provide a general roadmap, but the specifics will vary greatly depending on the chosen model.

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ except Exception:  # pragma: no cover - fallback when Flask isn't installed
     # The stub is only used for running the test suite without real Flask
     from flask_stub import Flask, request, render_template, jsonify
 from clothseg import ClothSegmenter
+from werkzeug.utils import secure_filename # Added for secure filenames
 from werkzeug.security import generate_password_hash, check_password_hash
 try:
     from sqlalchemy import Column, Integer, String, create_engine
@@ -112,40 +113,159 @@ def index():
 
 @app.route('/upload', methods=['POST'])
 def upload():
-    # In a real application you would process the uploaded file
-    file = request.files.get('image')
-    if file is None or file.filename == '':
-        return jsonify({'error': 'No file provided'}), 400
-    if not _is_allowed_image(file):
-        return jsonify({'error': 'Invalid file type'}), 400
-
-    # Save the uploaded file temporarily so it can be parsed.
-    tmp = tempfile.NamedTemporaryFile(delete=False)
-    temp_path = tmp.name
-    tmp.close()
-    file.save(temp_path)
-
     try:
-        parts = cloth_segmenter.parse(temp_path)
-    finally:
-        if os.path.exists(temp_path):
-            os.remove(temp_path)
+        full_body_image = request.files.get('full_body_image')
+        clothing_item_images = request.files.getlist('clothing_item_images')
 
-    part_names = ", ".join(parts.keys()) if parts else "unknown parts"
-    prompt = f"Suggest an outfit based on the clothing parts: {part_names}"
-    try:
-        chat = openai.ChatCompletion.create(
-            messages=[{"role": "user", "content": prompt}],
-            model="gpt-3.5-turbo",
-        )
-        suggestion_text = chat["choices"][0]["message"]["content"]
-        image = openai.Image.create(prompt=prompt)
-        image_url = image["data"][0]["url"]
-    except openai.error.OpenAIError:
-        logger.exception("OpenAI request failed")
-        return jsonify({"error": "OpenAI request failed"}), 502
+        # Validate full_body_image
+        if full_body_image is None or full_body_image.filename == '':
+            return jsonify({'error': 'Full body image is required'}), 400
+        if not _is_allowed_image(full_body_image):
+            return jsonify({'error': 'Invalid file type or size for full body image'}), 400
 
-    return jsonify({'suggestions': [suggestion_text], 'image_url': image_url})
+        # Validate clothing_item_images
+        if not clothing_item_images or all(not item.filename for item in clothing_item_images):
+            return jsonify({'error': 'At least one clothing item image is required'}), 400
+
+        clothing_attributes_list = []
+
+        for idx, item_image in enumerate(clothing_item_images):
+            if item_image.filename == '':
+                # This case might occur if multiple file inputs are used and some are left empty.
+                # Depending on strictness, we can ignore or error.
+                # For now, let's assume getlist filters out ones with no actual file selected by user.
+                # If an empty filename string IS passed for a selected file, it's an issue.
+                logger.warning(f"Skipping clothing item at index {idx} due to empty filename.")
+                continue # Or return error: jsonify({'error': f'Clothing item {idx+1} has no filename'}), 400
+
+            if not _is_allowed_image(item_image):
+                return jsonify({'error': f'Invalid file type or size for clothing item: {secure_filename(item_image.filename)}'}), 400
+
+            temp_path = ""
+            try:
+                # Secure the filename before using it in NamedTemporaryFile's suffix
+                s_filename = secure_filename(item_image.filename)
+                # Ensure suffix starts with a dot if that's what NamedTemporaryFile expects, or handle it if it adds one.
+                # os.path.splitext can give the extension directly.
+                _, ext = os.path.splitext(s_filename)
+                tmp = tempfile.NamedTemporaryFile(delete=False, suffix=ext)
+                temp_path = tmp.name
+                tmp.close() # Close before saving to it
+                item_image.save(temp_path)
+                
+                # Use cloth_segmenter.analyze to get attributes
+                analysis_result = cloth_segmenter.analyze(temp_path)
+                # Ensure 'attributes' key exists, default to empty dict if not
+                item_attributes = analysis_result.get('attributes', {})
+                if not item_attributes and 'parts' in analysis_result : # If attributes is empty but parts exist, maybe log or use parts as fallback
+                    logger.info(f"Clothing item {s_filename} yielded no specific attributes, but parts were segmented.")
+
+                clothing_attributes_list.append(item_attributes)
+
+            except Exception as e: # More specific exception handling can be added if needed
+                logger.error(f"Error processing clothing item {secure_filename(item_image.filename)}: {e}")
+                # Decide if one failed item should halt the whole request
+                return jsonify({'error': f'Error processing clothing item: {secure_filename(item_image.filename)}'}), 500
+            finally:
+                if temp_path and os.path.exists(temp_path):
+                    os.remove(temp_path)
+        
+        # Placeholder for full body image processing (if any needed beyond validation)
+        # For now, we just acknowledge its receipt.
+
+        # Construct prompt for OpenAI
+        prompt_items_list = []
+        if not clothing_attributes_list:
+            suggestion_text = "No clothing items were provided to suggest an outfit."
+        else:
+            for i, attributes in enumerate(clothing_attributes_list):
+                category = attributes.get('category', 'item')
+                color = attributes.get('color', '')
+                description = f"Item {i+1}: A "
+                if color and color.lower() != 'unknown':
+                    description += f"{color} "
+                description += category
+                prompt_items_list.append(description)
+
+            formatted_items = "\n".join(prompt_items_list)
+            prompt = (
+                "You are a fashion assistant. Based on the following available clothing items, please suggest 2-3 distinct outfits:\n\n"
+                "Available items:\n"
+                f"{formatted_items}\n\n"
+                "For each outfit, please describe which items are used and why they form a good combination. "
+                "Focus on color coordination and general style compatibility."
+            )
+
+            try:
+                chat_completion = openai.ChatCompletion.create(
+                    model="gpt-3.5-turbo",
+                    messages=[{"role": "user", "content": prompt}]
+                )
+                suggestion_text = chat_completion.choices[0].message.content
+            except openai.error.OpenAIError as e:
+                logger.error(f"OpenAI API request failed: {e}")
+                return jsonify({'error': 'OpenAI request failed while generating outfit suggestions'}), 502
+
+        # Initialize image generation related variables
+        generated_outfit_image_url = None
+        image_generation_error = None
+        final_message = "Outfit suggestion generated successfully."
+
+        # Attempt to generate an image if clothing items were processed
+        if clothing_attributes_list:
+            item_descriptions_for_image = []
+            for attributes in clothing_attributes_list:
+                category = attributes.get('category', 'item')
+                color = attributes.get('color', '')
+                desc_part = ""
+                if color and color.lower() != 'unknown':
+                    desc_part += f"{color} "
+                desc_part += category
+                if desc_part: # Avoid adding empty strings if both are unknown/empty
+                    item_descriptions_for_image.append(desc_part)
+            
+            if item_descriptions_for_image:
+                item_descriptions_string = ", ".join(item_descriptions_for_image)
+                image_prompt = (
+                    f"Generate a realistic image of a person wearing a stylish, coordinated outfit composed from some or all of the "
+                    f"following items: {item_descriptions_string}. Show a full-body view of the person. The background should be simple and neutral, "
+                    "making the outfit the main focus."
+                )
+                try:
+                    image_response = openai.Image.create(
+                        prompt=image_prompt,
+                        n=1,
+                        size="512x512" 
+                    )
+                    generated_outfit_image_url = image_response["data"][0]["url"]
+                    final_message = "Outfit suggestion and image generated successfully."
+                except openai.error.OpenAIError as e:
+                    logger.error(f"OpenAI Image API request failed: {e}")
+                    image_generation_error = "Failed to generate outfit image due to an API error."
+                    final_message = "Outfit suggestion generated, but image generation failed."
+            else:
+                image_generation_error = "Not enough item details to generate an image."
+                final_message = "Outfit suggestion generated. Image generation skipped due to lack of item details."
+        else:
+            # This case is for when suggestion_text was the default "No clothing items..."
+            final_message = "Outfit suggestion generated. Image generation skipped as no items were provided."
+
+
+        response_data = {
+            'message': final_message,
+            'clothing_items_attributes': clothing_attributes_list,
+            'user_image_info': {'filename': secure_filename(full_body_image.filename)},
+            'outfit_suggestions_text': suggestion_text,
+            'generated_outfit_image_url': generated_outfit_image_url
+        }
+        if image_generation_error:
+            response_data['image_generation_error'] = image_generation_error
+        
+        return jsonify(response_data), 200
+
+    except Exception as e:
+        logger.error(f"Error in /upload endpoint: {e}")
+        return jsonify({'error': 'Error processing images'}), 500
 
 
 @app.route('/parse', methods=['POST'])
@@ -216,6 +336,13 @@ def suggest():
 @app.route('/compose', methods=['POST'])
 def compose():
     """Combine a user photo with selected clothing images."""
+    # TODO: This endpoint currently uses OpenAI's general image generation based on a text prompt
+    # derived from the uploaded images. For a true virtual try-on experience (dressing the user's
+    # photo with specific clothes realistically), a specialized model (e.g., VITON-HD, or other
+    # GAN/Diffusion based models) would need to be integrated here. This would involve
+    # significant image processing (segmentation, pose estimation) for both the user image
+    # and the clothing items, and then feeding this data to the specialized model.
+    # See VIRTUAL_TRY_ON.md for more details on this advanced feature.
     body = request.files.get('body')
     clothes = []
     if hasattr(request.files, 'getlist'):
@@ -337,3 +464,99 @@ if __name__ == '__main__':
     flag = os.getenv('FLASK_DEBUG')
     debug_mode = flag.lower() in {'1', 'true', 'yes'} if flag is not None else False
     app.run(debug=debug_mode)
+
+
+@app.route('/refine_outfit_suggestion', methods=['POST'])
+def refine_outfit_suggestion():
+    try:
+        data = request.get_json()
+        if not data:
+            return jsonify({'error': 'Invalid JSON payload'}), 400
+
+        original_suggestion = data.get('original_suggestion')
+        available_clothing_items = data.get('available_clothing_items')
+        user_query = data.get('user_query')
+
+        missing_fields = []
+        if original_suggestion is None: # Allow empty string, but not None
+            missing_fields.append('original_suggestion')
+        if available_clothing_items is None: # Allow empty list, but not None
+            missing_fields.append('available_clothing_items')
+        if user_query is None: # Allow empty string, but not None
+            missing_fields.append('user_query')
+        
+        if missing_fields:
+            return jsonify({'error': f'Missing required fields: {", ".join(missing_fields)}'}), 400
+
+        if not isinstance(original_suggestion, str):
+            return jsonify({'error': 'Invalid type for original_suggestion, expected string'}), 400
+        if not isinstance(available_clothing_items, list):
+            return jsonify({'error': 'Invalid type for available_clothing_items, expected list'}), 400
+        if not isinstance(user_query, str):
+            return jsonify({'error': 'Invalid type for user_query, expected string'}), 400
+
+        for item in available_clothing_items:
+            if not isinstance(item, dict):
+                return jsonify({'error': 'Invalid item in available_clothing_items, expected list of dictionaries'}), 400
+
+        # Format available_clothing_items
+        formatted_available_items_list = []
+        if not available_clothing_items:
+            formatted_available_items = "No specific clothing items were listed as available by the user."
+        else:
+            for i, item_attrs in enumerate(available_clothing_items):
+                category = item_attrs.get('category', 'item')
+                color = item_attrs.get('color', '')
+                description = f"Item {i+1}: A "
+                if color and color.lower() != 'unknown':
+                    description += f"{color} "
+                description += category
+                formatted_available_items_list.append(description)
+            formatted_available_items = "\n".join(formatted_available_items_list)
+
+        # Construct the refinement prompt
+        refinement_prompt = (
+            "You are a fashion assistant. Here's the context:\n"
+            "The user has the following clothing items available:\n"
+            f"{formatted_available_items}\n\n"
+            "Previously, you provided these outfit suggestions:\n"
+            f'"{original_suggestion}"\n\n'
+            "Now, the user has a follow-up request:\n"
+            f'"{user_query}"\n\n'
+            "Please provide a new set of outfit suggestions or modifications based on the user's request, "
+            "keeping in mind the available items. If the request involves items not explicitly listed as available "
+            "(e.g., user mentions 'if I had white sneakers'), acknowledge this and provide advice accordingly, "
+            "perhaps suggesting how such an item would fit or offering alternatives from the available items."
+        )
+
+        # Call OpenAI ChatCompletion API
+        try:
+            chat_completion = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": refinement_prompt}]
+            )
+            refined_suggestion_text = chat_completion.choices[0].message.content
+        except openai.error.OpenAIError as e:
+            logger.error(f"OpenAI API request failed during refinement: {e}")
+            return jsonify({'error': 'OpenAI request failed during refinement'}), 502
+
+        # Generate follow_up_image_prompt
+        follow_up_image_prompt = None
+        if refined_suggestion_text and refined_suggestion_text.strip():
+            # Simple prompt based on a snippet of the refined text
+            prompt_snippet = refined_suggestion_text[:200].strip() # Take first 200 chars
+            follow_up_image_prompt = f"A realistic image depicting an outfit based on the following suggestion: \"{prompt_snippet}...\" Ensure the person and outfit are the main focus, with a simple, neutral background."
+        else:
+            follow_up_image_prompt = "No specific refined outfit details to visualize."
+            if not refined_suggestion_text: # if it was empty or None
+                 refined_suggestion_text = "The AI did not provide a specific textual refinement."
+
+
+        return jsonify({
+            "refined_suggestion_text": refined_suggestion_text,
+            "follow_up_image_prompt": follow_up_image_prompt
+        }), 200
+
+    except Exception as e:
+        logger.error(f"Error in /refine_outfit_suggestion endpoint: {e}")
+        return jsonify({'error': 'An unexpected error occurred processing your request'}), 500


### PR DESCRIPTION
I've made several enhancements to the outfit recommendation system:
- I modified the `/upload` endpoint to accept a full-body image and multiple clothing items. It processes these items, then uses OpenAI to generate textual outfit suggestions and a general visualization image.
- I added a `/refine_outfit_suggestion` endpoint to allow you to conversationally refine the AI's outfit suggestions.
- I introduced `SETUP_GUIDE.md`, providing comprehensive instructions for application setup, including dependencies, API key configuration, and model downloads.
- I added `VIRTUAL_TRY_ON.md`, a document outlining the concepts, challenges, and integration steps for implementing an advanced virtual try-on feature.
- I updated `README.md` to reference the new documentation.
- I added comments to `app.py` to clarify the role of certain endpoints, particularly `/compose` in relation to virtual try-on.